### PR TITLE
Update URLs to external docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Gradle example in **settings.gradle** file:
     }
 ```
 
-**Note:**  For [security](https://blog.autsoft.hu/a-confusing-dependency/) and performance reasons it is recommended to exclude the dependency search from other repositories using [filtering](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering).
+**Note:**  For [security](https://zsmb.co/a-confusing-dependency/) and performance reasons it is recommended to exclude the dependency search from other repositories using [filtering](https://docs.gradle.org/current/userguide/declaring_repositories_adv.html#sec:repository-content-filtering).
 
 ```gradle
       maven { 

--- a/_index.en.md
+++ b/_index.en.md
@@ -46,7 +46,7 @@ Gradle example in **settings.gradle** file:
     }
 ```
 
-**Note:**  For [security](https://blog.autsoft.hu/a-confusing-dependency/) and performance reasons it is recommended to exclude the dependency search from other repositories using [filtering](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering).
+**Note:**  For [security](https://zsmb.co/a-confusing-dependency/) and performance reasons it is recommended to exclude the dependency search from other repositories using [filtering](https://docs.gradle.org/current/userguide/declaring_repositories_adv.html#sec:repository-content-filtering).
 
 ```gradle
       maven { 

--- a/intro/_index.en.md
+++ b/intro/_index.en.md
@@ -52,7 +52,7 @@ Gradle example:
     }
 ```
 
-**Note:**  For [security](https://blog.autsoft.hu/a-confusing-dependency/) and performance reasons it is recommended to exclude the dependency search from other repositories using [filtering](https://docs.gradle.org/current/userguide/declaring_repositories.html#sec:repository-content-filtering).
+**Note:**  For [security](https://zsmb.co/a-confusing-dependency/) and performance reasons it is recommended to exclude the dependency search from other repositories using [filtering](https://docs.gradle.org/current/userguide/declaring_repositories_adv.html#sec:repository-content-filtering).
 
 ```gradle
       maven { 


### PR DESCRIPTION
Updates two outdated URLs:

1. URL to "A Confusing Dependency" blog was resulting in a "Server not Found" error. The same blog now exists at the updated zsmb.co URL.
2. Documentation for Repository Filtering in Gradle was moved as of Gradle 8.10. Updated the URL to the new page.